### PR TITLE
fix(logger): Removed redundant os.Exit call

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -3,7 +3,6 @@ package logger
 import (
 	"log"
 	"net/http"
-	"os"
 	"time"
 )
 
@@ -45,6 +44,5 @@ func CheckCriticalError(err error, context string) {
 func CheckFatalError(err error, context string) {
 	if err != nil {
 		log.Fatalf("[FATAL] %s: %v", context, err)
-		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Description

### Related Issues (if any)

## Type of Changes

Please mark the options that best describe your PR:

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [X] Refactor
- [ ] Documentation update
- [ ] CI/CD changes
- [ ] Dependencies update
- [ ] Other (please specify):

## Checklist

- [ ] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines for this project. (there isn't any!)
- [X] Added unit tests that cover the new/modified code.
- [X] All existing tests pass (``).
- [ ] Added or updated documentation if needed (e.g., `README.md`, code comments).
- [ ] Public functions and structs are well-documented using GoDoc conventions.
- [ ] If the PR introduces a new feature, it has been documented clearly for users.
- [ ] Ensure proper error handling and meaningful error messages.
- [ ] Ensure any logging follows best practices (e.g., no excessive or sensitive logging).
- [ ] Dependencies added are necessary and minimal.

## Additional Notes

This removes a redundant call to `os.Exit()`, as `log.Fatalf()` is called before it, which calls `os.Exit()`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling by allowing the program to continue running after logging a fatal error, improving overall stability.

- **Bug Fixes**
	- Removed unnecessary termination of the application on fatal errors, allowing for better error management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->