### PR TITLE
refactor: wrap handler function in a separate type

### DIFF
--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -5,5 +5,5 @@ import (
 )
 
 type Plugin interface {
-	Register(route func(method, path string, handler func(req *req.Request, res *req.Response)))
+	Register(route func(method, path string, handler req.Handler))
 }

--- a/req/types.go
+++ b/req/types.go
@@ -1,0 +1,3 @@
+package req
+
+type Handler func(r *Request, w *Response)

--- a/router/app.go
+++ b/router/app.go
@@ -44,7 +44,7 @@ func (a *App) RegisterPlugins() {
 	}
 }
 
-func (a *App) Route(method, path string, handler func(req *req.Request, res *req.Response)) {
+func (a *App) Route(method, path string, handler req.Handler) {
 	if a.routes[path] == nil {
 		a.routes[path] = make(map[string]http.HandlerFunc)
 	}
@@ -64,39 +64,39 @@ func (a *App) Route(method, path string, handler func(req *req.Request, res *req
 	a.routes[path][method] = h
 }
 
-func (a *App) Get(path string, handler func(req *req.Request, res *req.Response)) {
+func (a *App) Get(path string, handler req.Handler) {
 	a.Route(http.MethodGet, path, handler)
 }
 
-func (a *App) Post(path string, handler func(req *req.Request, res *req.Response)) {
+func (a *App) Post(path string, handler req.Handler) {
 	a.Route(http.MethodPost, path, handler)
 }
 
-func (a *App) Put(path string, handler func(req *req.Request, res *req.Response)) {
+func (a *App) Put(path string, handler req.Handler) {
 	a.Route(http.MethodPut, path, handler)
 }
 
-func (a *App) Delete(path string, handler func(req *req.Request, res *req.Response)) {
+func (a *App) Delete(path string, handler req.Handler) {
 	a.Route(http.MethodDelete, path, handler)
 }
 
-func (a *App) Patch(path string, handler func(req *req.Request, res *req.Response)) {
+func (a *App) Patch(path string, handler req.Handler) {
 	a.Route(http.MethodPatch, path, handler)
 }
 
-func (a *App) Options(path string, handler func(req *req.Request, res *req.Response)) {
+func (a *App) Options(path string, handler req.Handler) {
 	a.Route(http.MethodOptions, path, handler)
 }
 
-func (a *App) Head(path string, handler func(req *req.Request, res *req.Response)) {
+func (a *App) Head(path string, handler req.Handler) {
 	a.Route(http.MethodHead, path, handler)
 }
 
-func (a *App) Connect(path string, handler func(req *req.Request, res *req.Response)) {
+func (a *App) Connect(path string, handler req.Handler) {
 	a.Route(http.MethodConnect, path, handler)
 }
 
-func (a *App) Trace(path string, handler func(req *req.Request, res *req.Response)) {
+func (a *App) Trace(path string, handler req.Handler) {
 	a.Route(http.MethodTrace, path, handler)
 }
 


### PR DESCRIPTION
## Description
If I used the LSP autofill and used the default variable names, the suggestions would conflict as `req` is also a package name. So I renamed the arguments and wrapped function in a separate type to simplify further modifications
![image](https://github.com/user-attachments/assets/76ca7d00-45c4-4b83-8d21-5bbd514c1810)

### Related Issues (if any)

## Type of Changes

Please mark the options that best describe your PR:

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement
- [x] Refactor
- [ ] Documentation update
- [ ] CI/CD changes
- [ ] Dependencies update
- [ ] Other (please specify):

## Checklist

- [x] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines for this project.
- [ ] Added unit tests that cover the new/modified code.
- [x] All existing tests pass (`go test ./...`).
- [ ] Added or updated documentation if needed (e.g., `README.md`, code comments).
- [ ] Public functions and structs are well-documented using GoDoc conventions.
- [ ] If the PR introduces a new feature, it has been documented clearly for users.
- [ ] Ensure proper error handling and meaningful error messages.
- [ ] Ensure any logging follows best practices (e.g., no excessive or sensitive logging).
- [ ] Dependencies added are necessary and minimal.

## Additional Notes




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `req` package with a standardized `Handler` type for request handling.
  
- **Improvements**
	- Updated method signatures across routing methods to utilize the new `req.Handler` type, enhancing consistency in handler definitions.

- **Bug Fixes**
	- No specific bug fixes were included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->